### PR TITLE
Divine Justice Damage

### DIFF
--- a/components/builder/buildForm.js
+++ b/components/builder/buildForm.js
@@ -28,7 +28,8 @@ const enabledBoxes = {
     cloaked: false,
     secondwind: false,
     // Other Buffs
-    versatile: false
+    versatile: false,
+    divinejustice: false
 };
 
 const extraStats = {
@@ -54,7 +55,7 @@ function groupMasterwork(items, itemData) {
             items.splice(i, 1);
         }
     }
-    
+
     // Re-insert the groups as arrays into the items array.
     Object.keys(masterworkItems).forEach(item => {
         items.push({ value: `${item}-${masterworkItems[item][0].masterwork}`, label: item });
@@ -168,7 +169,7 @@ export default function BuildForm({ update, build, parentLoaded, itemData }) {
         let mainhands = ["mainhand", "mainhand sword", "mainhand shield", "axe", "pickaxe", "wand", "scythe", "bow", "crossbow", "snowball", "trident"];
         let offhands = ["offhand", "offhand shield", "offhand sword"];
         let actualItemType = (mainhands.includes(itemType.toLowerCase())) ? "mainhand" : (offhands.includes(itemType.toLowerCase())) ? "offhand" : itemType.toLowerCase();
-        
+
         const manualBuildString = encodeURI(decodeURI(makeBuildString()).replace(newBuild[actualItemType.toLowerCase()], `${newActiveItem.name}-${newActiveItem.masterwork}`));
         newBuild[actualItemType.toLowerCase()] = `${newActiveItem.name}-${newActiveItem.masterwork}`;
         itemRefs[actualItemType.toLowerCase()].current.setValue({ "value": `${newActiveItem.name}-${newActiveItem.masterwork}`, "label": newActiveItem.name });
@@ -307,6 +308,7 @@ export default function BuildForm({ update, build, parentLoaded, itemData }) {
                 <CheckboxWithLabel name="Tempo" checked={false} onChange={checkboxChanged} />
                 <CheckboxWithLabel name="Cloaked" checked={false} onChange={checkboxChanged} />
                 <CheckboxWithLabel name="Versatile" checked={false} onChange={checkboxChanged} />
+                <CheckboxWithLabel name="DivineJustice" checked={false} onChange={checkboxChanged} />
             </div>
             <div className="row justify-content-center my-2">
                 <div className="col text-center">

--- a/pages/builder.js
+++ b/pages/builder.js
@@ -107,7 +107,8 @@ export default function Builder({ build, itemData }) {
         { type: "magicDamagePercent", name: "builder.stats.magic.magicDamagePercent", percent: true },
         { type: "spellPowerPercent", name: "builder.stats.magic.spellPowerPercent", percent: true },
         { type: "spellDamage", name: "builder.stats.magic.spellDamage", percent: true },
-        { type: "spellCooldownPercent", name: "builder.stats.magic.spellCooldownPercent", percent: true }
+        { type: "spellCooldownPercent", name: "builder.stats.magic.spellCooldownPercent", percent: true },
+        { type: "divineJusticeDamage", name: "builder.stats.magic.divineJusticeDamage",percent:false}
     ];
 
 

--- a/utils/builder/stats.js
+++ b/utils/builder/stats.js
@@ -16,7 +16,7 @@ class Stats {
 
         this.fullItemData = {};
         types.forEach(type => {
-            this.fullItemData[type] = (this.itemNames[type] != "None") ? 
+            this.fullItemData[type] = (this.itemNames[type] != "None") ?
                 (itemData[this.itemNames[type]]) ? itemData[this.itemNames[type]] : {masterwork: 0} : {masterwork: 0};
         });
 
@@ -107,6 +107,7 @@ class Stats {
         this.iframeDPS = ((attackSpeed >= 2) ? attackDamage * 2 : attackDamage * attackSpeed).toFixed(2);
         this.iframeCritDPS = ((attackSpeed >= 2) ? attackDamageCrit * 2 : attackDamageCrit * attackSpeed).toFixed(2);
 
+
         // Projectile Stats
         let projectileDamage = this.sumNumberStat(this.itemStats.mainhand, "projectile_damage_base", this.projectileDamage)
             * this.projectileDamagePercent.val
@@ -134,6 +135,11 @@ class Stats {
         this.spellCooldownPercent = this.spellCooldownPercent
             .mul(Math.pow(0.95, this.aptitude + this.ineptitude), false)
             .toFixedPerc(2);
+        // Divine Justice (look, I would argue it's melee, but it's also magic, so I'm just putting it below both)
+        if (this.enabledBoxes.divinejustice) {
+          let divineJusticeDamage = ((attackDamageCrit * 0.2) + 5) * 1.15 * (this.magicDamagePercent/100);
+          this.divineJusticeDamage = divineJusticeDamage.toFixed(2);
+        }
     }
 
     calculateDefenseStats() {
@@ -194,7 +200,7 @@ class Stats {
         damageTaken.base = damageTaken.base
             * (1 - (this.tenacity * 0.005))
             * (this.extraResistanceMultiplier.val);
-        
+
         damageTaken.secondwind = damageTaken.secondwind
             * (1 - (this.tenacity * 0.005))
             * (this.extraResistanceMultiplier.val);
@@ -490,6 +496,7 @@ class Stats {
         this.spellPowerPercent = new Percentage(100),
         this.spellDamage = new Percentage(100),
         this.spellCooldownPercent = new Percentage(100),
+        this.divineJusticeDamage = 0,
 
         this.aptitude = 0,
         this.ineptitude = 0,

--- a/utils/items/statFormatter.js
+++ b/utils/items/statFormatter.js
@@ -76,9 +76,9 @@ const categories = {
     ],
     "other_curse": [
         ...["ineptitude", "curse_of_shrapnel", "curse_of_vanishing", "projectile_fragility", "melee_fragility",
-            "magic_fragility", "blast_fragility", "fire_fragility", "starvation","curse_of_instability"]
+            "magic_fragility", "blast_fragility", "fire_fragility", "starvation",]
             .map(entry => ({ name: entry, format: Formats.CURSE })),
-        ...["two_handed", "curse_of_corruption", "curse_of_irreparability", "cumbersome"]
+        ...["two_handed", "curse_of_corruption", "curse_of_irreparability", "cumbersome","curse_of_instability"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_CURSE }))
     ],
     "water": [
@@ -171,7 +171,7 @@ class StatFormatter {
             return "";
         }
         let formattedStats = [];
-        
+
         for (const category in categories) {
             for (const stat of categories[category]) {
                 if (stats[stat.name]) {

--- a/utils/items/statFormatter.js
+++ b/utils/items/statFormatter.js
@@ -26,7 +26,7 @@ const categories = {
     ],
     "misc": [
         ...["second_wind", "inferno", "regicide", "aptitude", "triage", "trivium", "looting",
-            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect"]
+            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect","reverb"]
             .map(entry => ({ name: entry, format: Formats.ENCHANT })),
         ...["intuition", "weightless", "radiant", "darksight", "void_tether", "resurrection", "infinity"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_ENCHANT }))
@@ -76,7 +76,7 @@ const categories = {
     ],
     "other_curse": [
         ...["ineptitude", "curse_of_shrapnel", "curse_of_vanishing", "projectile_fragility", "melee_fragility",
-            "magic_fragility", "blast_fragility", "fire_fragility", "starvation"]
+            "magic_fragility", "blast_fragility", "fire_fragility", "starvation","curse_of_instability"]
             .map(entry => ({ name: entry, format: Formats.CURSE })),
         ...["two_handed", "curse_of_corruption", "curse_of_irreparability", "cumbersome"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_CURSE }))

--- a/utils/translation/languages/en.json
+++ b/utils/translation/languages/en.json
@@ -221,6 +221,7 @@
     "builder.stats.magic.spellPowerPercent": "Spell Power",
     "builder.stats.magic.spellDamage": "Total Magic Damage",
     "builder.stats.magic.spellCooldownPercent": "Cooldown Duration",
+    "builder.stats.magic.divineJusticeDamage": "Divine Justice Damage",
 
     "builder.multipliers.damage": "Damage Multipliers",
     "builder.multipliers.resistance": "Resistance Multipliers",


### PR DESCRIPTION
Adds a toggle in Situationals to enable Divine Justice Damage in melee stats, scaling off of crit damage, assuming luminous infusion 2's 15% damage boost, and then magic damage. Inspired by noticing versatile chilling up there, and went "yeah, I could implement a divine justice damage calc"

Only localized for English because I did *not* feel like adding any other translations. 

Also may accidentally have copied over my reverb/instability addition due to poor source control, but that's mb