### PR TITLE
Misc formatting fixes

### DIFF
--- a/pages/builder.js
+++ b/pages/builder.js
@@ -273,6 +273,17 @@ export async function getServerSideProps(context) {
                 delete itemData[item];
             }
         }
+        switch (itemStats.location){
+          case "Skr":
+            itemData[item].location = "Silver Knight's Remnants";
+            break;
+          case "SKT":
+            itemData[item].location = "Silver Knight's Tomb";
+            break;
+          case "Overworld3":
+            itemData[item].location = "Architect's Ring Overworld";
+            break;
+        }
     }
 
     return {

--- a/pages/items.js
+++ b/pages/items.js
@@ -45,27 +45,27 @@ function getRelevantItems(data, itemData, exaltedNameList) {
     if (wantedItemTypes.length > 0) {
         items = items.filter(name => wantedItemTypes.includes(itemData[name].type));
     }
-    
+
     let wantedRegions = extractFilterValues(data, "regionSelect");
     if (wantedRegions.length > 0) {
         items = items.filter(name => wantedRegions.includes(itemData[name].region));
     }
-    
+
     let wantedTiers = extractFilterValues(data, "tierSelect");
     if (wantedTiers.length > 0) {
         items = items.filter(name => wantedTiers.includes(itemData[name].tier));
     }
-    
+
     let wantedLocations = extractFilterValues(data, "locationSelect");
     if (wantedLocations.length > 0) {
         items = items.filter(name => wantedLocations.includes(itemData[name].location));
     }
-    
+
     let wantedPois = extractFilterValues(data, "poiSelect");
     if (wantedPois.length > 0) {
         items = items.filter(name => itemData[name].extras?.poi && wantedPois.includes(itemData[name].extras.poi));
     }
-    
+
     let wantedClasses = extractFilterValues(data, "classSelect");
     if (wantedClasses.length > 0) {
         items = items.filter(name => wantedClasses.includes(itemData[name].class_name));
@@ -171,7 +171,7 @@ export default function Items({ itemData }) {
                         <TranslatableText identifier="items.searchForm.itemsFound"></TranslatableText> {relevantItems.length}
                     </h4> : ""
                 }
-                
+
                 <InfiniteScroll
                     className={styles.itemsContainer}
                     dataLength={itemsToShow}
@@ -249,6 +249,21 @@ export async function getServerSideProps(context) {
                 delete itemData[item];
             }
         }
+        if(itemStats.location == "Skr"){
+          itemData[item].location = "Silver Knight's Remnants";
+        }
+        switch (itemStats.location){
+          case "Skr":
+            itemData[item].location = "Silver Knight's Remnants";
+            break;
+          case "SKT":
+            itemData[item].location = "Silver Knight's Tomb";
+            break;
+          case "Overworld3":
+            itemData[item].location = "Architect's Ring Overworld";
+            break;
+        }
+
     }
 
     return {

--- a/styles/Items.module.css
+++ b/styles/Items.module.css
@@ -277,7 +277,7 @@
     color: #6f3508;
 }
 
-.sKT {
+.silverKnightsTomb {
     color: #bebebe;
 }
 
@@ -487,6 +487,14 @@
 
 .theEternalVigil {
     color: #71979A;
+}
+
+.silverKnightsRemnants {
+    color: #eaca99;
+}
+
+.architectsRingOverworld{
+  color: #c7c9c9
 }
 
 .exalted {

--- a/utils/items/statFormatter.js
+++ b/utils/items/statFormatter.js
@@ -26,7 +26,7 @@ const categories = {
     ],
     "misc": [
         ...["second_wind", "inferno", "regicide", "aptitude", "triage", "trivium", "looting",
-            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect","reverb"]
+            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect"]
             .map(entry => ({ name: entry, format: Formats.ENCHANT })),
         ...["intuition", "weightless", "radiant", "darksight", "void_tether", "resurrection", "infinity", "clucking",
             "baaing", "oinking"]
@@ -77,7 +77,7 @@ const categories = {
     ],
     "other_curse": [
         ...["ineptitude", "curse_of_shrapnel", "curse_of_vanishing", "projectile_fragility", "melee_fragility",
-            "magic_fragility", "blast_fragility", "fire_fragility", "starvation","curse_of_instability"]
+            "magic_fragility", "blast_fragility", "fire_fragility", "starvation"]
             .map(entry => ({ name: entry, format: Formats.CURSE })),
         ...["two_handed", "curse_of_corruption", "curse_of_irreparability", "curse_of_instability", "cumbersome"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_CURSE }))

--- a/utils/items/statFormatter.js
+++ b/utils/items/statFormatter.js
@@ -26,7 +26,7 @@ const categories = {
     ],
     "misc": [
         ...["second_wind", "inferno", "regicide", "aptitude", "triage", "trivium", "looting",
-            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect"]
+            "ice_aspect", "fire_aspect", "thunder_aspect", "wind_aspect", "earth_aspect","reverb"]
             .map(entry => ({ name: entry, format: Formats.ENCHANT })),
         ...["intuition", "weightless", "radiant", "darksight", "void_tether", "resurrection", "infinity"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_ENCHANT }))
@@ -76,7 +76,7 @@ const categories = {
     ],
     "other_curse": [
         ...["ineptitude", "curse_of_shrapnel", "curse_of_vanishing", "projectile_fragility", "melee_fragility",
-            "magic_fragility", "blast_fragility", "fire_fragility", "starvation"]
+            "magic_fragility", "blast_fragility", "fire_fragility", "starvation","curse_of_instability"]
             .map(entry => ({ name: entry, format: Formats.CURSE })),
         ...["two_handed", "curse_of_corruption", "curse_of_irreparability", "cumbersome"]
             .map(entry => ({ name: entry, format: Formats.SINGLE_CURSE }))


### PR DESCRIPTION
Added color and formatted Silver Knight's Remnants as such instead of as "Skr," replaced SKT text with "Silver Knight's Tomb," and replaced "Overworld3" tag on Emblem of Wrath with a properly colored and formatted "Architect's Ring Overworld" tag like it has in game.

This is really only a single commit, however I biffed my git commits (I'm still relatively new to git) and forgot to make a branch before working on these fixes. Whoopsie daisy, I've discard all the changes so it's only the aforementioned changes that are actually included in this PR.